### PR TITLE
Set `dstDepth` when input is `stdin`

### DIFF
--- a/apps/avifenc.c
+++ b/apps/avifenc.c
@@ -387,6 +387,9 @@ static avifBool avifInputReadImage(avifInput * input,
             fprintf(stderr, "ERROR: Cannot read y4m through standard input");
             return AVIF_FALSE;
         }
+        if (dstDepth) {
+            *dstDepth = dstImage->depth;
+        }
         assert(dstImage->yuvFormat != AVIF_PIXEL_FORMAT_NONE);
         if (dstSourceIsRGB) {
             *dstSourceIsRGB = AVIF_FALSE;


### PR DESCRIPTION
...otherwise the sanity checker would report
```
WARNING: [--lossless] Input depth (0) does not match output depth (8). Output might not be lossless.
```
in `--lossless` mode and `--stdin` input. Also see [the correct handling when file name is supplied](https://github.com/AOMediaCodec/libavif/blob/f8eaf32ba85828528c41f97e78da2d8f24d1f2b8/apps/shared/avifutil.c#L259).